### PR TITLE
feat: add boardready style landing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import SideNav from "@/components/SideNav";
 import LayoutVars from "@/components/LayoutVars";
 import { Suspense } from "react";
 import GlobalSkeleton from "@/components/GlobalSkeleton";
+import { headers } from "next/headers";
 
 const jakarta = Plus_Jakarta_Sans({
   subsets: ["latin"],
@@ -23,6 +24,9 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const pathname = headers().get("next-url") || "";
+  const isLanding = pathname === "/";
+
   return (
     <html lang="de" className={jakarta.variable}>
       <body className="bg-[var(--bg)] text-[var(--fg)]">
@@ -30,24 +34,30 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <div className="flex min-h-screen flex-col">
             <Header />
 
-            <div className="mx-auto w-full max-w-screen-2xl px-6 py-6 flex-1">
-              {/* Grid mit fixer Sidebar */}
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-[var(--nav-w)_1fr] items-start">
-                {/* Sidebar links */}
-                <aside className="hidden md:block">
-                  <div className="sticky top-20">
-                    <SideNav />
-                  </div>
-                </aside>
+            {isLanding ? (
+              <div className="flex-1">
+                {children}
+              </div>
+            ) : (
+              <div className="mx-auto w-full max-w-screen-2xl px-6 py-6 flex-1">
+                {/* Grid mit fixer Sidebar */}
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-[var(--nav-w)_1fr] items-start">
+                  {/* Sidebar links */}
+                  <aside className="hidden md:block">
+                    <div className="sticky top-20">
+                      <SideNav />
+                    </div>
+                  </aside>
 
-                {/* Seiteninhalt rechts mit Suspense */}
-                <div>
-                  <Suspense fallback={<GlobalSkeleton />}>
-                    {children}
-                  </Suspense>
+                  {/* Seiteninhalt rechts mit Suspense */}
+                  <div>
+                    <Suspense fallback={<GlobalSkeleton />}>
+                      {children}
+                    </Suspense>
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
 
             <div className="mt-auto">
               <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,31 @@
-import { redirect } from "next/navigation";
+import Link from "next/link";
 
 export default function Home() {
-  redirect("/subjects");
+  return (
+    <main className="relative overflow-hidden bg-gradient-to-b from-[#0f1524] via-[#152033] to-[#1c2640] text-white">
+      <section className="mx-auto max-w-4xl px-6 py-32 text-center">
+        <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+          Bereit fürs M3 – mit ExaSim
+        </h1>
+        <p className="mt-4 text-lg text-gray-300">
+          Prüfungsnahe Fälle und Simulationen für eine moderne Vorbereitung.
+        </p>
+        <div className="mt-8 flex justify-center gap-4">
+          <Link
+            href="/register"
+            className="rounded-md bg-blue-600 px-6 py-3 font-semibold text-white shadow hover:bg-blue-500"
+          >
+            Jetzt starten
+          </Link>
+          <Link
+            href="/subjects"
+            className="rounded-md border border-white/20 px-6 py-3 font-semibold text-white hover:bg-white/10"
+          >
+            Mehr erfahren
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
 }
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,10 @@
 // src/components/Footer.tsx
 export default function Footer() {
   return (
-    <footer className="mt-16 border-t border-black/10 dark:border-white/10">
-      <div className="mx-auto max-w-5xl px-4 py-6 text-xs text-gray-500">
-        © {new Date().getFullYear()} ExaSim · Lernsimulation, keine medizinische Beratung.
-      </div>
-    </footer>
-  );
-}
+      <footer className="mt-16 border-t border-black/10">
+        <div className="mx-auto max-w-5xl px-4 py-6 text-xs text-gray-400">
+          © {new Date().getFullYear()} ExaSim · Lernsimulation, keine medizinische Beratung.
+        </div>
+      </footer>
+    );
+  }


### PR DESCRIPTION
## Summary
- add hero landing page with gradient and CTA buttons
- hide sidebar layout on landing page
- tweak footer for dark background compatibility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font `Plus Jakarta Sans` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68c6fc51f9948330abb46f9a2761edec