### PR TITLE
Enhance examiner guidance and loading feedback

### DIFF
--- a/src/app/api/exam/turn/route.ts
+++ b/src/app/api/exam/turn/route.ts
@@ -573,6 +573,8 @@ KONTEXT-REGELN
 - Beziehe dich NUR auf Vignette + bereits preisgegebene Infos.
 - Keine neuen Befunde erfinden.
 - Bewerte ausschließlich die AKTUELLE Frage (CURRENT_STEP_PROMPT).
+- Greife ausdrücklich die zuletzt genannten Inhalte der/des Studierenden auf (kurz paraphrasieren oder zitieren).
+- Verknüpfe deine Antwort mit dem konkreten Krankheitsbild und nenne – wo möglich – den passenden Fachbegriff.
 
 KUMULATIVE WERTUNG (wichtig)
 - Entscheide die Korrektheit nach der **Gesamtheit** der bisher genannten Inhalte in diesem Schritt.
@@ -583,27 +585,33 @@ KUMULATIVE WERTUNG (wichtig)
 - Doppelnennungen zählen nicht mehrfach;
 - Falls etwas falsch geschrieben ist, z.b. Rechtschreibung stark abweichend; Tippfehler, ausgelassene Buchstaben, verdrehte Buchstaben und Schreibweisen nach Lautsprache (z. B. „Kolezüstitis“ für „Cholezystitis“), dann auch als richtig zählen.
 
-NO-LEAK GUARD (streng)
-- In attemptStage 1/2 (und im Tipp-Modus) keine neuen Diagnosen/Beispiele/Synonyme/Hinweise, die nicht von der/dem Studierenden stammen.
-- Nur Meta-Feedback (z. B. Organsysteme/Struktur/Anzahl), keine Inhalte verraten.
-- Genutzte Begriffe darfst du korrigieren, aber **keine** neuen Inhalte einführen.
+THEORIE & PRIORITÄT (immer)
+- Nach jeder Bewertung (correct/partial/incorrect) musst du eine kurze Theoriesequenz liefern: Satz 1 „Theoretisch passend wäre …“ (korrekte Zielantwort/erwarteter Befund). Satz 2 „Aktuell zweitrangig, weil …“ (warum der Schritt jetzt keine höchste Priorität hat).
+- Diese Theoriesequenz ist IMMER erlaubt, auch in attemptStage 1/2.
+- Halte diesen Zusatz insgesamt auf maximal zwei Sätze.
+
+NO-LEAK GUARD (angepasst)
+- In attemptStage 1/2 (und im Tipp-Modus) keine zusätzlichen Beispiele/Synonyme außer in der verpflichtenden Theoriesequenz.
+- Nutze die Theoriesequenz, um die korrekte Lösung zu nennen und die Priorität einzuordnen.
+- Genutzte Begriffe darfst du korrigieren, aber **keine** weiteren neuen Inhalte einführen.
 
 AUSDRUCK & TON
 -  Keine Emojis/Auslassungspunkte/Klammer-Meta.
-- Bei correct/partial/incorrect kurze, klare Begründung auf Meta-Ebene.
+- Bei correct/partial/incorrect klare Begründung auf Meta-Ebene, die auf den konkreten Aussagen des Studierenden aufsetzt.
 
 VERSUCHSLOGIK (hart)
 - Drei Versuche (attemptStage 1..3). Give-up zählt wie 3.
 - attemptStage 1/2 UND nicht korrekt:
-  • evaluation.feedback = 1 kurzer Satz Bewertung + 1 kurzer Satz Lücke/Strukturhinweis (ohne Beispiele/Diagnosen).
+  • evaluation.feedback = 2–3 Sätze: 1 Satz Bewertung, 1 Satz zur Lücke/Struktur (ohne neue Beispiele), danach die Theoriesequenz.
   • evaluation.tips = weglassen (nur im Tipp-Modus).
   • next_question = null.
 - attemptStage 3 ODER Give-up:
   • say_to_student MUSS mit "Lösung:" beginnen. Danach 1 Kernsatz + was noch gefehlt hat + 2–3 knappe Bullets (• Kerngedanke • Abgrenzung • nächster Schritt).
   • next_question = NEXT_STEP_PROMPT (falls vorhanden), sonst null.
 - Antwort ist korrekt:
-  • evaluation.feedback = 1 kurzer Bestätigungssatz + 2–3 Meta-Bullets ( warum passend • Kategorie/Pathomechanismus auf Meta-Ebene • Priorität).
+  • evaluation.feedback = 1 kurzer Bestätigungssatz + 2–3 Meta-Bullets (warum passend • Kategorie/Pathomechanismus • Priorität) – beziehe dich darin auf konkrete Studierendeninhalte.
   • next_question = NEXT_STEP_PROMPT (falls vorhanden); end=true falls letzter Schritt.
+- next_question (wenn gesetzt): Formuliere sie als sanften Übergang, erwähne in einem Halbsatz den zuvor besprochenen Punkt und leite dann – ggf. leicht umformuliert – in den Inhalt von NEXT_STEP_PROMPT über.
 
 TIPP-MODUS (tipRequest=true)
 - Nur "say_to_student" mit 1–2 neutralen Strukturhinweisen (keine Diagnosen/Beispiele). "evaluation" und "next_question" bleiben null.


### PR DESCRIPTION
## Summary
- instruct the examiner prompt to reference student answers, share the theoretical solution with priority context, and craft smoother question transitions
- store LLM-provided follow-up questions for each step and reset overrides when restarting an exam session
- show a pulsating dot while waiting for the examiner response to better signal API loading

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca87b8926c8330b1677fd9bea37c9d