### PR TITLE
Add interactive exam mode for Aszites case

### DIFF
--- a/src/app/cases/CasesClient.tsx
+++ b/src/app/cases/CasesClient.tsx
@@ -8,9 +8,11 @@ import {
   ChevronRightIcon,
   FolderIcon,
   CheckCircleIcon,
+  SparklesIcon,
 } from "@heroicons/react/24/outline";
 import { CASES } from "@/data/cases";
 import type { Case } from "@/lib/types";
+import { hasExamModeCase } from "@/data/exam-mode";
 
 /* ---------- Utils ---------- */
 function neutralLabel(idx: number) {
@@ -265,6 +267,15 @@ export default function SymptomsPage() {
                     </div>
 
                     <div className="flex shrink-0 items-center gap-2">
+                      {hasExamModeCase(c.id) && (
+                        <Link
+                          href={`/exam-mode/${c.id}`}
+                          className="hidden sm:inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-2 text-sm text-white hover:bg-emerald-700"
+                          title="Neuer Prüfungsmodus"
+                        >
+                          Neu <SparklesIcon className="h-4 w-4" />
+                        </Link>
+                      )}
                       <Link
                         href={`/exam/${c.id}`}
                         className="inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700"

--- a/src/app/cases/[id]/page.tsx
+++ b/src/app/cases/[id]/page.tsx
@@ -6,6 +6,8 @@ import Link from "next/link";
 import { CASES } from "@/data/cases";
 import type { Case } from "@/lib/types";
 import CaseImagePublic from "@/components/CaseImagePublic"; // ✅ Bild-Komponente einbinden
+import { hasExamModeCase } from "@/data/exam-mode";
+import { SparklesIcon } from "@heroicons/react/24/outline";
 
 type ExtendedCase = Case & {
   specialty?: string;     // Fach (legacy-kompatibel)
@@ -43,6 +45,8 @@ export default function CaseDetail() {
 
   // robuste Navigation (unabhängig von <Link>)
   const goStart = () => router.push(`/exam/${c.id}`);
+  const goStartNewMode = () => router.push(`/exam-mode/${c.id}`);
+  const supportsNewMode = hasExamModeCase(c.id);
 
   return (
     <main className="mx-auto max-w-3xl p-6">
@@ -57,6 +61,15 @@ export default function CaseDetail() {
           >
             Prüfung starten
           </button>
+          {supportsNewMode && (
+            <button
+              type="button"
+              onClick={goStartNewMode}
+              className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+            >
+              Neuer Prüfungsmodus <SparklesIcon className="h-4 w-4" />
+            </button>
+          )}
           <Link
             href="/subjects"
             className="inline-flex items-center rounded-md border border-black/10 bg-white px-4 py-2 text-sm hover:bg-black/[.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
@@ -115,6 +128,15 @@ export default function CaseDetail() {
         >
           Prüfung starten
         </button>
+        {supportsNewMode && (
+          <button
+            type="button"
+            onClick={goStartNewMode}
+            className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+          >
+            Neuer Prüfungsmodus <SparklesIcon className="h-4 w-4" />
+          </button>
+        )}
         <Link
           href="/subjects"
           className="inline-flex items-center rounded-md border border-black/10 bg-white px-4 py-2 text-sm hover:bg-black/[.04] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"

--- a/src/app/exam-mode/[id]/page.tsx
+++ b/src/app/exam-mode/[id]/page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import CaseImagePublic from "@/components/CaseImagePublic";
+import { getExamModeCase } from "@/data/exam-mode";
+import type { ExamModeCase } from "@/lib/types";
+import {
+  createInitialExamModeState,
+  evaluateExamModeInput,
+  type ExamModeEvaluation,
+  type ExamModeState,
+} from "@/lib/exam-mode";
+
+type Message = {
+  role: "tutor" | "student";
+  text: string;
+  image?: ExamModeCase["actions"][string]["image"];
+};
+
+function MessageBubble({ message }: { message: Message }) {
+  const isStudent = message.role === "student";
+  const alignment = isStudent ? "items-end" : "items-start";
+  const bubbleClass = isStudent
+    ? "self-end rounded-2xl rounded-br-sm bg-blue-600 text-white"
+    : "self-start rounded-2xl rounded-bl-sm bg-gray-100 text-gray-900";
+
+  return (
+    <div className={`flex flex-col ${alignment} gap-2`}>
+      <div className={`${bubbleClass} max-w-[85%] px-4 py-3 text-sm shadow-sm`}>{message.text}</div>
+      {message.image && (
+        <figure className="max-w-[85%] overflow-hidden rounded-xl border border-black/10 bg-white">
+          <CaseImagePublic
+            path={message.image.path}
+            alt={message.image.alt}
+            caption={message.image.caption}
+            zoomable
+          />
+          {message.image.caption && (
+            <figcaption className="border-t border-black/10 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+              {message.image.caption}
+            </figcaption>
+          )}
+        </figure>
+      )}
+    </div>
+  );
+}
+
+function defaultText(kind: ExamModeEvaluation["kind"], caseData: ExamModeCase, actionKey?: string): string {
+  switch (kind) {
+    case "locked":
+      return caseData.lockedMessage || "Diese Maßnahme ist im Moment nicht verfügbar.";
+    case "unknown":
+      return caseData.unknownMessage || "Ich habe Sie nicht verstanden. Bitte formulieren Sie Ihre Maßnahme genauer.";
+    case "repeat":
+      if (actionKey) {
+        const action = caseData.actions[actionKey];
+        if (action?.repeatResponse) return action.repeatResponse;
+      }
+      return caseData.repeatMessage || "Dieser Schritt wurde bereits durchgeführt.";
+    default:
+      return "";
+  }
+}
+
+export default function ExamModePage() {
+  const params = useParams<{ id: string | string[] }>();
+  const router = useRouter();
+  const rawId = params?.id;
+  const caseId = Array.isArray(rawId) ? rawId[0] : rawId || "";
+  const caseData = useMemo<ExamModeCase | null>(() => getExamModeCase(caseId), [caseId]);
+
+  const [state, setState] = useState<ExamModeState | null>(() =>
+    caseData ? createInitialExamModeState(caseData) : null
+  );
+  const [messages, setMessages] = useState<Message[]>(() =>
+    caseData
+      ? [
+          {
+            role: "tutor",
+            text: `${caseData.vignette} Wie gehen Sie vor?`,
+          },
+        ]
+      : []
+  );
+  const [input, setInput] = useState("");
+
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!caseData) {
+      setState(null);
+      setMessages([]);
+      return;
+    }
+    setState(createInitialExamModeState(caseData));
+    setMessages([
+      {
+        role: "tutor",
+        text: `${caseData.vignette} Wie gehen Sie vor?`,
+      },
+    ]);
+    setInput("");
+  }, [caseData]);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    listRef.current.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  const disabled = !caseData || !state || state.finished;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!caseData || !state) return;
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    const { evaluation, nextState } = evaluateExamModeInput(caseData, state, trimmed);
+    setState(nextState);
+    setInput("");
+
+    setMessages((prev) => {
+      const base: Message[] = [...prev, { role: "student", text: trimmed }];
+
+      if (evaluation.kind === "success") {
+        const followUps: Message[] = [
+          {
+            role: "tutor",
+            text: evaluation.action.response,
+            image: evaluation.action.image,
+          },
+        ];
+        if (evaluation.finished && caseData.completionMessage) {
+          followUps.push({ role: "tutor", text: caseData.completionMessage });
+        }
+        return [...base, ...followUps];
+      }
+
+      const text = defaultText(evaluation.kind, caseData, "actionKey" in evaluation ? evaluation.actionKey : undefined);
+      return [...base, { role: "tutor", text }];
+    });
+  }
+
+  function handleReset() {
+    if (!caseData) return;
+    setState(createInitialExamModeState(caseData));
+    setMessages([
+      {
+        role: "tutor",
+        text: `${caseData.vignette} Wie gehen Sie vor?`,
+      },
+    ]);
+    setInput("");
+  }
+
+  if (!caseData) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <h1 className="mb-3 text-2xl font-semibold tracking-tight">Prüfungsmodus</h1>
+        <p className="mb-4 text-sm text-gray-600">
+          Für diesen Fall steht der neue Prüfungsmodus noch nicht zur Verfügung.
+        </p>
+        <div className="flex gap-2">
+          <Link
+            href="/subjects"
+            className="rounded-md border border-black/10 bg-white px-3 py-1.5 text-sm hover:bg-black/[.04]"
+          >
+            Zur Fallübersicht
+          </Link>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="rounded-md border border-black/10 bg-white px-3 py-1.5 text-sm hover:bg-black/[.04]"
+          >
+            Zurück
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col p-6">
+      <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">{caseData.title}</h1>
+          <p className="text-sm text-gray-600">Interaktiver Prüfungsmodus</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href={`/cases/${caseData.id}`}
+            className="inline-flex items-center rounded-md border border-black/10 bg-white px-3 py-1.5 text-sm hover:bg-black/[.04]"
+          >
+            Fallbeschreibung
+          </Link>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="inline-flex items-center rounded-md border border-black/10 bg-white px-3 py-1.5 text-sm hover:bg-black/[.04]"
+          >
+            Neu starten
+          </button>
+        </div>
+      </header>
+
+      <section
+        ref={listRef}
+        className="mb-4 flex max-h-[65vh] flex-1 flex-col gap-4 overflow-y-auto rounded-2xl border border-black/10 bg-white/80 p-4"
+      >
+        {messages.map((m, idx) => (
+          <MessageBubble key={idx} message={m} />
+        ))}
+        {state?.finished && (
+          <div className="self-start text-xs text-emerald-600">
+            Fall abgeschlossen – Sie können den Verlauf jederzeit neu starten.
+          </div>
+        )}
+      </section>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Beschreiben Sie Ihre nächste Maßnahme"
+          className="h-11 flex-1 rounded-md border border-black/10 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          disabled={disabled}
+        />
+        <button
+          type="submit"
+          className="h-11 rounded-md bg-blue-600 px-5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+          disabled={disabled}
+        >
+          Senden
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { CASES } from "@/data/cases";
 import type { Case } from "@/lib/types";
+import { hasExamModeCase } from "@/data/exam-mode";
+import { SparklesIcon } from "@heroicons/react/24/outline";
 
 // Lokale Erweiterung um optionale Meta-Felder aus deinen Daten
 type CaseWithMeta = Case & Partial<{
@@ -99,13 +101,21 @@ export default function SearchPage() {
                   </span>
                 )}
               </div>
-              <div className="mt-3 flex gap-2">
+              <div className="mt-3 flex flex-wrap gap-2">
                 <Link
                   href={`/cases/${c.id}`}
                   className="rounded-md border px-3 py-1 text-xs hover:bg-black/[.04]"
                 >
                   Details
                 </Link>
+                {hasExamModeCase(c.id) && (
+                  <Link
+                    href={`/exam-mode/${c.id}`}
+                    className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1 text-xs text-white hover:bg-emerald-700"
+                  >
+                    Neuer Prüfungsmodus <SparklesIcon className="h-4 w-4" />
+                  </Link>
+                )}
                 <Link
                   href={`/exam/${c.id}`}
                   className="rounded-md bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700"

--- a/src/app/subjects/[subject]/[category]/page.tsx
+++ b/src/app/subjects/[subject]/[category]/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import type { Case } from "@/lib/types";  
+import type { Case } from "@/lib/types";
 import { useEffect, useMemo, useState } from "react";
 import { slugify, subjectFromSlug } from "@/lib/slug";
 import { useParams } from "next/navigation";
 import { motion } from "framer-motion";
+import { SparklesIcon } from "@heroicons/react/24/outline";
+import { hasExamModeCase } from "@/data/exam-mode";
 
 export default function CategoryCasesPage() {
   const params = useParams<{ subject: string; category: string }>();
@@ -50,10 +52,18 @@ export default function CategoryCasesPage() {
           >
             <h3 className="font-medium">{c.title}</h3>
             <p className="text-sm text-gray-600 mt-1 line-clamp-2">{c.vignette}</p>
-            <div className="mt-3 flex gap-2">
+            <div className="mt-3 flex flex-wrap gap-2">
               <Link href={`/cases/${c.id}`} className="rounded-md border px-3 py-1.5 text-sm hover:bg-black/[.04]">
                 Details
               </Link>
+              {hasExamModeCase(c.id) && (
+                <Link
+                  href={`/exam-mode/${c.id}`}
+                  className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm text-white hover:bg-emerald-700"
+                >
+                  Neuer Prüfungsmodus <SparklesIcon className="h-4 w-4" />
+                </Link>
+              )}
               <Link href={`/exam/${c.id}`} className="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700">
                 Prüfungsmodus
               </Link>

--- a/src/app/subjects/subjects-inner.tsx
+++ b/src/app/subjects/subjects-inner.tsx
@@ -4,9 +4,10 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
-import { FolderIcon, ArrowRightIcon, ChevronRightIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import { FolderIcon, ArrowRightIcon, ChevronRightIcon, CheckCircleIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import type { Case } from "@/lib/types";
 import { CASES } from "@/data/cases";
+import { hasExamModeCase } from "@/data/exam-mode";
 
 /* ---------- Utils ---------- */
 function shortName(c: Case) {
@@ -285,6 +286,15 @@ export default function SubjectsPageInner() {
                       >
                         Details
                       </Link>
+                      {hasExamModeCase(c.id) && (
+                        <Link
+                          href={`/exam-mode/${c.id}`}
+                          className="hidden sm:inline-flex items-center gap-1 rounded-md bg-emerald-600 px-2.5 py-1.5 text-sm text-white hover:bg-emerald-700"
+                          title="Neuer Prüfungsmodus"
+                        >
+                          Neu <SparklesIcon className="h-4 w-4" />
+                        </Link>
+                      )}
                       <Link
                         href={`/exam/${c.id}`}
                         className="inline-flex items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1.5 text-sm text-white hover:bg-blue-700"

--- a/src/components/CaseMiniCard.tsx
+++ b/src/components/CaseMiniCard.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { FolderIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
+import { FolderIcon, ArrowRightIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import type { Case } from "@/lib/types";
+import { hasExamModeCase } from "@/data/exam-mode";
 
 function deriveShort(title: string) {
   // nimmt Teil vor –/—/- oder kürzt sanft
@@ -38,6 +39,15 @@ export default function CaseMiniCard({ c }: { c: Case }) {
         >
           Details
         </Link>
+        {hasExamModeCase(c.id) && (
+          <Link
+            href={`/exam-mode/${c.id}`}
+            className="hidden sm:inline-flex items-center gap-1 rounded-md bg-emerald-600 px-2.5 py-1.5 text-sm text-white hover:bg-emerald-700"
+            title="Neuer Prüfungsmodus"
+          >
+            Neu <SparklesIcon className="h-4 w-4" />
+          </Link>
+        )}
         <Link
           href={`/exam/${c.id}`}
           className="inline-flex items-center gap-1 rounded-md bg-blue-600 px-2.5 py-1.5 text-sm text-white hover:bg-blue-700"

--- a/src/components/SubjectsExplorer.tsx
+++ b/src/components/SubjectsExplorer.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { FolderIcon } from "@heroicons/react/24/outline";
+import { FolderIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import type { Case } from "@/lib/types";
 import Badge from "@/components/Badge";
+import { hasExamModeCase } from "@/data/exam-mode";
 
 // -----------------------------
 // Utils (ohne any)
@@ -195,13 +196,21 @@ export default function SubjectsExplorer({ cases }: { cases: Case[] }) {
                     <Badge key={t}>{t}</Badge>
                   ))}
                 </div>
-                <div className="mt-4 flex gap-2">
+                <div className="mt-4 flex flex-wrap gap-2">
                   <Link
                     href={`/cases/${c.id}`}
                     className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm hover:bg-black/[.04]"
                   >
                     Details
                   </Link>
+                  {hasExamModeCase(c.id) && (
+                    <Link
+                      href={`/exam-mode/${c.id}`}
+                      className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-sm text-white hover:bg-emerald-700"
+                    >
+                      Neuer Prüfungsmodus <SparklesIcon className="h-4 w-4" />
+                    </Link>
+                  )}
                   <Link
                     href={`/exam/${c.id}`}
                     className="inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"

--- a/src/data/cases.ts
+++ b/src/data/cases.ts
@@ -6,6 +6,7 @@ import { hypertonie_001 } from "./innere/kardiologie/hypertonie_001";
 import { pankreatitis_001 } from "./innere/gastroenterologie/pankreatitis_001";
 import { spannungspneumothorax_001 } from "./chirurgie/Thoraxchirurgie/spannungspneumothorax_001";
 import { mm_001 } from "./innere/haematoonkologie/mm_001";
+import { aszites_001 } from "./innere/gastroenterologie/aszites_001";
 
 export const CASES = [
   brustschmerz_001,
@@ -15,5 +16,6 @@ export const CASES = [
   hypertonie_001,
   pankreatitis_001,
   spannungspneumothorax_001,
-  mm_001
+  mm_001,
+  aszites_001,
 ];

--- a/src/data/exam-mode/index.ts
+++ b/src/data/exam-mode/index.ts
@@ -1,0 +1,16 @@
+import { aszites_001_exam } from "../innere/gastroenterologie/aszites_001";
+import type { ExamModeCase } from "@/lib/types";
+
+export const EXAM_MODE_CASES: ExamModeCase[] = [aszites_001_exam];
+
+const EXAM_MODE_CASE_MAP = new Map(EXAM_MODE_CASES.map((c) => [c.id, c] as const));
+
+export function getExamModeCase(id: string | null | undefined): ExamModeCase | null {
+  if (!id) return null;
+  return EXAM_MODE_CASE_MAP.get(id) ?? null;
+}
+
+export function hasExamModeCase(id: string | null | undefined): boolean {
+  if (!id) return false;
+  return EXAM_MODE_CASE_MAP.has(id);
+}

--- a/src/data/innere/gastroenterologie/aszites_001.ts
+++ b/src/data/innere/gastroenterologie/aszites_001.ts
@@ -1,0 +1,334 @@
+import type { Case, ExamModeCase } from "@/lib/types";
+
+const ID = "aszites_001";
+const TITLE = "Bauchumfangszunahme und Dyspnoe";
+const SHORT_TITLE = "Aszites";
+const LEAD_SYMPTOM = "Abdominelle Schwellung";
+const VIGNETTE =
+  "Sie sind Arzt in der Notaufnahme. Ein 58-jähriger Patient stellt sich bei Ihnen vor. Er berichtet über einen seit Wochen zunehmenden Bauchumfang, Spannungsgefühl im Abdomen und Belastungsdyspnoe.";
+
+export const aszites_001: Case = {
+  id: ID,
+  title: TITLE,
+  shortTitle: SHORT_TITLE,
+  leadSymptom: LEAD_SYMPTOM,
+  pseudonym: "Aszites_001",
+  vignette: VIGNETTE + " Welche anamnestischen Fragen stellen Sie?",
+
+  specialty: "Innere Medizin",
+  subspecialty: "Gastroenterologie",
+  difficulty: 3,
+  tags: ["Aszites", "Portale Hypertension", "Leberzirrhose", "Ösophagusvarizen"],
+
+  steps: [
+    {
+      order: 1,
+      points: 2,
+      prompt: "Welche anamnestischen Fragen stellen Sie?",
+      hint: "Lebererkrankung, Blutungen, Risikofaktoren, B-Symptomatik",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Alkoholkonsum",
+          "Risikofaktoren",
+          "Rauchen",
+          "Vorerkrankungen",
+          "(Vor-) Operationen",
+          "B-Symptomatik (Gewichtsverlust, Schwitzen, Fieber)",
+          "Medikation",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 2,
+      points: 2,
+      prompt:
+        "Sie wollen nun den Patienten körperlich untersuchen, auf was achten Sie im Speziellen?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Bauchumfang vergrößert",
+          "prall gefüllter Bauch",
+          "Aszites nachweisbar (Flüssigkeitswelle, shifting dullness)",
+          "Ödeme",
+          "Splenomegalie",
+          "Ikterus",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 3,
+      points: 2,
+      prompt: "Welche initiale Diagnostik ist indiziert?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Sonografie des Abdomens",
+          "Labor (Leberwerte, Gerinnung, Kreatinin, Elektrolyte)",
+          "Aszitespunktion (Untersuchung Eiweiß, Zellzahl, Mikrobiologie)",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 4,
+      points: 3,
+      prompt:
+        "Sie entschließen sich, eine Abdomensonografie durchzuführen. Dabei ergibt sich folgendes Bild. Beschreiben Sie:",
+      rule: {
+        mode: "anyOf",
+        expected: ["Aszites", "Echoleere Flüssigkeit um die Leber", "Hinweis auf Leberzirrhose"],
+        minHits: 2,
+      },
+      image: {
+        path: "Ultraschall/Aszites.JPG",
+        alt: "Sonografie mit freier Flüssigkeit im Abdomen",
+        caption: "Sonografie des Abdomens: Nachweis von Aszites (freie Flüssigkeit).",
+      },
+    },
+    {
+      order: 5,
+      points: 2,
+      prompt:
+        "Sie haben die anschließende diagnostische Aszitespunktion erfolgreich durchgeführt und wollen nun eine Probe davon zum Labor schicken. Welche Laborparameter sind dabei von besonderem Interesse?",
+      rule: {
+        mode: "anyOf",
+        expected: ["Zellzahl", "Eiweißgehalt", "Mikrobiologische Untersuchung"],
+        minHits: 2,
+      },
+    },
+    {
+      order: 6,
+      points: 3,
+      prompt:
+        "Inzwischen ist auch folgender Laborbefund des Blutes eingetroffen. Interpretieren Sie erst die Ergebnisse und äußern Sie eine dazu passende Differentialdiagnose.",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Erhöhte Transaminasen",
+          "Hypoalbuminämie",
+          "Erhöhte INR / Gerinnungsstörung",
+          "Leberzirrhose",
+          "Erhöhte Leberwerte",
+          "erhöhte cholestasewerte",
+          "Lebersynthesefunktion eingeschränkt",
+          "Gerinnungsstörung",
+        ],
+        minHits: 3,
+      },
+      image: {
+        path: "Labor/Leberzirrhose.png",
+        alt: "Laborbefund mit erhöhten Transaminasen und erniedrigtem Albumin",
+        caption: "Typischer Laborbefund bei fortgeschrittener Leberzirrhose.",
+      },
+    },
+    {
+      order: 7,
+      points: 3,
+      prompt: "Welche typischen Ursachen einer portalen Hypertension kennen Sie?",
+      hint: "Prä-, intra- und posthepatisch unterscheiden",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Pfortaderthrombose",
+          "Leberzirrhose",
+          "Schistosomiasis",
+          "Sinusoidales Okklusionssyndrom",
+          "Budd-Chiari-Syndrom",
+          "(Rechts)herzinsuffizienz",
+          "Pericarditis constrictiva",
+          "Leber(teil)resektion",
+        ],
+        minHits: 3,
+      },
+    },
+    {
+      order: 8,
+      points: 2,
+      prompt:
+        "Während Sie die Laborwerte interpretieren, klagt der Patient plötzlich über Schwindel, wird blass und beginnt Blut zu erbrechen. Welche Symptome deuten auf eine akute Varizenblutung hin?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Hämatemesis",
+          "Schockzeichen (Tachykardie, Hypotonie, Blässe, Kaltschweißigkeit)",
+          "Schwindel",
+          "Synkope",
+          "Frischblutiges Erbrechen",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 9,
+      points: 3,
+      prompt: "Welche sofortigen Maßnahmen zur Kreislaufstabilisierung leiten Sie ein?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Schocklage",
+          "Bluttransfusion je nach Schwere",
+          "Magensonde",
+          "Absaugen Blut",
+          "Schutzintubation als Aspirationsprophylaxe",
+          "Sauerstoffgabe",
+          "Volumentherapie",
+          "Anlage von großlumigen Zugängen",
+          "Vorbereitung einer Bluttransfusion",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 10,
+      points: 3,
+      prompt: "Sie leiten umgehend die Notfallversorgung ein. Welches Verfahren ist hier abgebildet?",
+      rule: {
+        mode: "anyOf",
+        expected: ["Ösophagusvarizenligatur", "Gummibandligatur", "Endoskopische Ligatur"],
+        minHits: 1,
+      },
+      image: {
+        path: "Endoskopie/Oesophagusvarizenligatur.png",
+        alt: "Sonografie mit freier Flüssigkeit im Abdomen",
+        caption: "Sonografie des Abdomens: Nachweis von Aszites (freie Flüssigkeit).",
+      },
+    },
+    {
+      order: 11,
+      points: 3,
+      prompt:
+        "Welche spezifischen Therapien zur Blutstillung bei Ösophagusvarizenblutung kommen außerdem infrage ?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Terlipressin oder Somatostatin/Octreotid",
+          "Sklerotherapie (falls Ligatur nicht möglich)",
+          "Ballontamponade (Sengstaken-Blakemore-Sonde) als Notfallmaßnahme",
+          "Stenting Ösophagus",
+          "TIPS",
+        ],
+        minHits: 1,
+      },
+    },
+    {
+      order: 12,
+      points: 2,
+      prompt:
+        "Welche Maßnahmen ergreifen Sie zur Sekundärprophylaxe nach einer überstandenen Varizenblutung?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Nicht-selektive Betablocker (z.B. Propranolol)",
+          "Regelmäßige endoskopische Ligatur",
+          "TIPS bei rezidivierender Blutung",
+          "Alkoholkarenz",
+          "Therapie der Grunderkrankung (Leberzirrhose)",
+        ],
+        minHits: 2,
+      },
+    },
+  ],
+
+  objectives: [
+    { id: "diagnose", label: "Aszites diagnostizieren" },
+    { id: "ursachen", label: "Ätiologie der portalen Hypertension benennen" },
+    { id: "notfall", label: "Akute Varizenblutung erkennen und behandeln" },
+    { id: "therapie", label: "Therapieoptionen und Prophylaxe darstellen" },
+  ],
+
+  completion: { minObjectives: 4, maxLLMTurns: 20, hardStopTurns: 20 },
+};
+
+export const aszites_001_exam: ExamModeCase = {
+  id: ID,
+  title: TITLE,
+  vignette: VIGNETTE,
+  startActions: ["anamnese"],
+  completionActions: ["sekundaerprophylaxe"],
+  completionMessage:
+    "Sehr gut, Sie haben den kompletten Fall von der Erstvorstellung bis zur Sekundärprophylaxe begleitet.",
+  lockedMessage: "Diese Maßnahme steht aktuell nicht zur Verfügung.",
+  unknownMessage: "Ich habe Sie nicht verstanden. Bitte benennen Sie die gewünschte Maßnahme präziser.",
+  repeatMessage: "Dieser Schritt wurde bereits durchgeführt.",
+  actions: {
+    anamnese: {
+      keywords: ["anamnese", "fragen", "vorerkrank", "alkohol", "medikament"],
+      response:
+        "Sie erheben die Anamnese: Alkoholkonsum, Risikofaktoren, Vorerkrankungen, Operationen, Medikamente, B-Symptomatik.",
+      unlocks: ["koerperliche_untersuchung", "labor", "sonografie"],
+    },
+    koerperliche_untersuchung: {
+      keywords: ["körperlich", "untersuchung", "bauch", "status"],
+      response:
+        "Körperlicher Status: vergrößerter Bauchumfang, prall gefüllter Bauch, Aszites nachweisbar (Flüssigkeitswelle, shifting dullness), periphere Ödeme, mögliche Splenomegalie und Ikterus.",
+      unlocks: ["sonografie", "labor"],
+    },
+    sonografie: {
+      keywords: ["sono", "ultraschall", "bild", "abdomen"],
+      response: "Sonografie des Abdomens: echoleere Flüssigkeit um die Leber, freie Flüssigkeit im Abdomen.",
+      image: {
+        path: "Ultraschall/Aszites.JPG",
+        alt: "Sonografie mit freier Flüssigkeit im Abdomen",
+        caption: "Sonografie des Abdomens",
+      },
+      unlocks: ["aszitespunktion"],
+    },
+    labor: {
+      keywords: ["labor", "werte", "blutbild", "transaminasen", "inr", "albumin"],
+      response: "Labor: Transaminasen erhöht, Albumin erniedrigt, INR verlängert.",
+      image: {
+        path: "Labor/Leberzirrhose.png",
+        alt: "Laborbefund",
+        caption: "Laborbefund mit eingeschränkter Leberfunktion",
+      },
+      unlocks: ["differenzialdiagnose"],
+    },
+    aszitespunktion: {
+      keywords: ["punktion", "aszites", "flüssigkeit", "punktat"],
+      response: "Aszitespunktion: Analyse von Eiweißgehalt, Zellzahl und Mikrobiologie (transsudativ).",
+      unlocks: ["differenzialdiagnose"],
+    },
+    differenzialdiagnose: {
+      keywords: ["diagnose", "differenzial", "dd"],
+      response:
+        "Differenzialdiagnosen der portalen Hypertension: Leberzirrhose, Pfortaderthrombose, Schistosomiasis, Budd-Chiari-Syndrom, Rechtsherzinsuffizienz, Pericarditis constrictiva.",
+      unlocks: ["notfall_varizenblutung"],
+    },
+    notfall_varizenblutung: {
+      keywords: ["notfall", "blutet", "blutung", "varizen"],
+      response:
+        "Der Patient wird plötzlich blass, klagt über Schwindel und erbricht frisches Blut (Hämatemesis, Schockzeichen).",
+      unlocks: ["notfall_massnahmen"],
+    },
+    notfall_massnahmen: {
+      keywords: ["maßnahmen", "stabilisierung", "schock", "kreislauf"],
+      response:
+        "Akutmaßnahmen: Schocklage, großlumige Zugänge, Volumentherapie, Sauerstoffgabe, Absaugen/Magensonde, ggf. Schutzintubation, Vorbereitung der Bluttransfusion.",
+      unlocks: ["endoskopie"],
+    },
+    endoskopie: {
+      keywords: ["endoskopie", "ligatur", "varizen", "gummiband"],
+      response: "Endoskopische Therapie: Ösophagusvarizenligatur (Gummibandligatur).",
+      image: {
+        path: "Endoskopie/Oesophagusvarizenligatur.png",
+        alt: "Endoskopische Ligatur von Ösophagusvarizen",
+        caption: "Endoskopische Ligatur",
+      },
+      unlocks: ["blutstillung_medikament"],
+    },
+    blutstillung_medikament: {
+      keywords: ["medikament", "blutstillung", "therapie", "terlipressin", "octreotid"],
+      response:
+        "Medikamentöse Unterstützung: Terlipressin oder Somatostatin/Octreotid. Alternativen: Sklerotherapie, Ballontamponade, Ösophagus-Stent, TIPS.",
+      unlocks: ["sekundaerprophylaxe"],
+    },
+    sekundaerprophylaxe: {
+      keywords: ["sekundär", "prophylaxe", "betablocker", "rezidiv"],
+      response:
+        "Sekundärprophylaxe: nicht-selektive Betablocker, regelmäßige endoskopische Ligaturen, TIPS bei Rezidiv, Alkoholkarenz, Behandlung der Grunderkrankung.",
+    },
+  },
+};

--- a/src/lib/exam-mode.ts
+++ b/src/lib/exam-mode.ts
@@ -1,0 +1,100 @@
+// src/lib/exam-mode.ts
+import type { ExamModeAction, ExamModeCase } from "./types";
+
+export type ExamModeState = {
+  unlocked: Set<string>;
+  completed: Set<string>;
+  finished: boolean;
+};
+
+export type ExamModeEvaluation =
+  | {
+      kind: "success";
+      actionKey: string;
+      action: ExamModeAction;
+      newlyUnlocked: string[];
+      finished: boolean;
+    }
+  | {
+      kind: "repeat";
+      actionKey: string;
+      action: ExamModeAction;
+    }
+  | { kind: "locked"; actionKey: string }
+  | { kind: "unknown" };
+
+export function createInitialExamModeState(caseData: ExamModeCase): ExamModeState {
+  return {
+    unlocked: new Set(caseData.startActions),
+    completed: new Set<string>(),
+    finished: false,
+  };
+}
+
+export function evaluateExamModeInput(
+  caseData: ExamModeCase,
+  state: ExamModeState,
+  rawInput: string
+): { evaluation: ExamModeEvaluation; nextState: ExamModeState } {
+  const normalized = (rawInput || "").toLowerCase();
+  const entries = Object.entries(caseData.actions);
+
+  for (const [key, action] of entries) {
+    const hits = action.keywords.some((kw) => normalized.includes(kw.toLowerCase()));
+    if (!hits) continue;
+
+    if (!state.unlocked.has(key)) {
+      return {
+        evaluation: { kind: "locked", actionKey: key },
+        nextState: state,
+      };
+    }
+
+    const nextUnlocked = new Set(state.unlocked);
+    const nextCompleted = new Set(state.completed);
+    const alreadyDone = nextCompleted.has(key);
+
+    let newlyUnlocked: string[] = [];
+
+    if (!alreadyDone) {
+      if (Array.isArray(action.unlocks) && action.unlocks.length) {
+        newlyUnlocked = action.unlocks.filter((u) => !nextUnlocked.has(u));
+        for (const u of action.unlocks) {
+          nextUnlocked.add(u);
+        }
+      }
+      nextCompleted.add(key);
+    }
+
+    const completesCase = !alreadyDone && caseData.completionActions?.includes(key);
+
+    const nextState: ExamModeState = {
+      unlocked: nextUnlocked,
+      completed: nextCompleted,
+      finished: state.finished || Boolean(completesCase),
+    };
+
+    if (alreadyDone) {
+      return {
+        evaluation: { kind: "repeat", actionKey: key, action },
+        nextState,
+      };
+    }
+
+    return {
+      evaluation: {
+        kind: "success",
+        actionKey: key,
+        action,
+        newlyUnlocked,
+        finished: nextState.finished,
+      },
+      nextState,
+    };
+  }
+
+  return {
+    evaluation: { kind: "unknown" },
+    nextState: state,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,6 +101,28 @@ export type Step = {
   reveal?: StepReveal;    // optionale Zusatzinfos
 };
 
+// ---------- Interaktiver Prüfungsmodus ----------
+export type ExamModeAction = {
+  keywords: string[];         // welche Eingaben diese Aktion triggern
+  response: string;           // Tutor-Antwort
+  image?: StepImage;          // optionales Bild zum Schritt
+  unlocks?: string[];         // weitere Aktionen, die danach verfügbar werden
+  repeatResponse?: string;    // optionale Antwort, wenn erneut angefragt
+};
+
+export type ExamModeCase = {
+  id: string;
+  title: string;
+  vignette: string;
+  startActions: string[];
+  actions: Record<string, ExamModeAction>;
+  completionActions?: string[];
+  completionMessage?: string;
+  lockedMessage?: string;
+  unknownMessage?: string;
+  repeatMessage?: string;
+};
+
 export type LearningObjective = {
   id: string;             // z. B. "ddx", "therapie"
   label: string;          // UI-Text


### PR DESCRIPTION
## Summary
- add dedicated types and engine utilities for the interactive exam mode
- provide the Aszites case with unlockable tutor actions and register it for the new mode
- surface the new exam mode via a dedicated page and entry points across the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caa004b8d483308c292c886a2eca29