### PR TITLE
Add dynamic exam mode with interactive case engine

### DIFF
--- a/src/app/pruefung/[id]/PruefungClient.tsx
+++ b/src/app/pruefung/[id]/PruefungClient.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import CaseImagePublic from "@/components/CaseImagePublic";
+import { InteractiveCaseEngine } from "@/lib/interactive-engine";
+import type { Case, StepImage } from "@/lib/types";
+
+type Message = {
+  role: "tutor" | "student";
+  text: string;
+  image?: StepImage;
+};
+
+type Props = {
+  caseData: Case;
+};
+
+export default function PruefungClient({ caseData }: Props) {
+  const interactive = caseData.interactive;
+  const [engine] = useState(() => (interactive ? new InteractiveCaseEngine(caseData) : null));
+
+  const [messages, setMessages] = useState<Message[]>(() => {
+    const introMessages: Message[] = [];
+    introMessages.push({ role: "tutor", text: caseData.vignette });
+    const intro = interactive?.intro;
+    if (intro) {
+      introMessages.push({ role: "tutor", text: intro });
+    }
+    return introMessages;
+  });
+
+  const [input, setInput] = useState("");
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const listRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!listRef.current) return;
+    listRef.current.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  const available = Boolean(interactive && engine);
+
+  const tutorFallbacks = useMemo(
+    () => ({
+      locked: interactive?.fallbacks?.locked || "Diese Maßnahme steht noch nicht zur Verfügung.",
+      unknown: interactive?.fallbacks?.unknown || "Ich habe das nicht verstanden. Welche Maßnahme planen Sie?",
+      finished: interactive?.fallbacks?.finished || "Der Fall ist bereits abgeschlossen.",
+    }),
+    [interactive]
+  );
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = input.trim();
+    if (!trimmed || !available || !engine) return;
+
+    setStatusMessage(null);
+    setMessages((prev) => [...prev, { role: "student", text: trimmed }]);
+    setInput("");
+
+    const result = engine.handleInput(trimmed);
+
+    if (result.type === "success") {
+      setMessages((prev) => {
+        const next: Message[] = [...prev, { role: "tutor", text: result.response, image: result.image }];
+        if (result.finished && result.completionMessage) {
+          next.push({ role: "tutor", text: result.completionMessage });
+        }
+        return next;
+      });
+      return;
+    }
+
+    if (result.type === "finished") {
+      setMessages((prev) => [...prev, { role: "tutor", text: result.message || tutorFallbacks.finished }]);
+      return;
+    }
+
+    if (result.type === "locked") {
+      setMessages((prev) => [...prev, { role: "tutor", text: result.message || tutorFallbacks.locked }]);
+      return;
+    }
+
+    setMessages((prev) => [...prev, { role: "tutor", text: result.message || tutorFallbacks.unknown }]);
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <header className="space-y-1">
+        <div className="text-sm text-gray-500">
+          <Link href="/pruefung" className="text-brand-700 hover:text-brand-800">
+            Zur Fallauswahl
+          </Link>
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight">{caseData.title}</h1>
+        <p className="text-sm text-gray-600">
+          {caseData.specialty} {caseData.subspecialty ? `- ${caseData.subspecialty}` : ""}
+        </p>
+      </header>
+
+      {!available ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          Für diesen Fall ist noch kein Prüfungsmodus hinterlegt.
+        </div>
+      ) : (
+        <>
+          <section
+            ref={listRef}
+            className="flex-1 space-y-4 overflow-y-auto rounded-2xl border border-black/10 bg-white/80 p-4 shadow-sm"
+          >
+            {messages.map((msg, idx) => (
+              <article key={idx} className="space-y-3">
+                <p
+                  className={
+                    msg.role === "student"
+                      ? "ml-auto max-w-[85%] rounded-2xl bg-brand-700 px-4 py-2 text-sm text-white shadow"
+                      : "max-w-[85%] rounded-2xl bg-gray-100 px-4 py-2 text-sm text-gray-900 shadow"
+                  }
+                >
+                  {msg.text}
+                </p>
+                {msg.image && msg.role === "tutor" && (
+                  <div className="max-w-xl">
+                    <CaseImagePublic path={msg.image.path} alt={msg.image.alt} caption={msg.image.caption} />
+                  </div>
+                )}
+              </article>
+            ))}
+          </section>
+
+          <form onSubmit={onSubmit} className="space-y-3">
+            {statusMessage && <p className="text-sm text-red-600">{statusMessage}</p>}
+            <label className="block text-sm font-medium text-gray-700" htmlFor="student-input">
+              Ihre nächste Maßnahme
+            </label>
+            <textarea
+              id="student-input"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              rows={3}
+              className="w-full resize-none rounded-xl border border-black/10 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-200"
+              placeholder={'z. B. "Anamnese erheben" oder "grosslumige Zugange legen"'}
+            />
+            <div className="flex justify-between gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  if (!engine) return;
+                  engine.reset();
+                  setMessages(() => {
+                    const introMessages: Message[] = [];
+                    introMessages.push({ role: "tutor", text: caseData.vignette });
+                    const intro = interactive?.intro;
+                    if (intro) {
+                      introMessages.push({ role: "tutor", text: intro });
+                    }
+                    return introMessages;
+                  });
+                  setStatusMessage(null);
+                }}
+                className="rounded-lg border border-black/10 px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+              >
+                Fall zurücksetzen
+              </button>
+              <button
+                type="submit"
+                className="inline-flex items-center rounded-lg bg-brand-700 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+              >
+                Antwort senden
+              </button>
+            </div>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/pruefung/[id]/page.tsx
+++ b/src/app/pruefung/[id]/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { CASES } from "@/data/cases";
+import PruefungClient from "./PruefungClient";
+
+function getCase(id: string) {
+  return CASES.find((c) => c.id === id) ?? null;
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  const caseData = getCase(params.id);
+  if (!caseData) {
+    return {
+      title: "Fall nicht gefunden – Prüfungsmodus",
+    };
+  }
+  return {
+    title: `${caseData.title} – Prüfungsmodus`,
+    description: caseData.vignette,
+  };
+}
+
+export default function PruefungCasePage({ params }: { params: { id: string } }) {
+  const caseData = getCase(params.id);
+  if (!caseData || !caseData.interactive) {
+    notFound();
+  }
+
+  return <PruefungClient caseData={caseData} />;
+}

--- a/src/app/pruefung/page.tsx
+++ b/src/app/pruefung/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { CASES } from "@/data/cases";
+
+export const metadata = {
+  title: "Prüfungsmodus – ExaSim",
+  description:
+    "Trainiere dynamische M3-Fallgespräche mit frei wählbaren Maßnahmen und unmittelbarem Tutor-Feedback.",
+};
+
+export default function PruefungOverviewPage() {
+  const interactiveCases = CASES.filter((c) => c.interactive);
+
+  return (
+    <main className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Prüfungsmodus</h1>
+        <p className="max-w-3xl text-sm text-gray-600">
+          Spiele mündliche Prüfungssituationen Schritt für Schritt nach. Du steuerst den Ablauf, der Tutor reagiert
+          ausschließlich auf deine Eingaben und nutzt nur die hinterlegten Falldaten.
+        </p>
+      </header>
+
+      {interactiveCases.length === 0 ? (
+        <p className="text-sm text-gray-600">Aktuell sind keine Fälle für den Prüfungsmodus verfügbar.</p>
+      ) : (
+        <ul className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(320px,1fr))]">
+          {interactiveCases.map((c) => (
+            <li key={c.id} className="rounded-2xl border border-black/10 bg-white/80 p-4 shadow-sm">
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-gray-900">{c.title}</h2>
+                <p className="text-sm text-gray-600">{c.vignette}</p>
+                <dl className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+                  {c.leadSymptom && (
+                    <div>
+                      <dt className="font-medium text-gray-700">Leitsymptom</dt>
+                      <dd>{c.leadSymptom}</dd>
+                    </div>
+                  )}
+                  {c.specialty && (
+                    <div>
+                      <dt className="font-medium text-gray-700">Fach</dt>
+                      <dd>{c.specialty}</dd>
+                    </div>
+                  )}
+                </dl>
+              </div>
+              <div className="mt-4">
+                <Link
+                  href={`/pruefung/${c.id}`}
+                  className="inline-flex items-center rounded-lg bg-brand-700 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+                >
+                  Fall starten
+                </Link>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -12,6 +12,7 @@ import {
   ShoppingBagIcon,
   BookOpenIcon,
   ClipboardDocumentListIcon,
+  ChatBubbleLeftRightIcon,
   ChevronDownIcon, // Icon fürs Auf-/Zuklappen
 } from "@heroicons/react/24/outline";
 
@@ -26,6 +27,7 @@ const NAV: Item[] = [
   { href: "/overview", label: "Übersicht", icon: HomeIcon },
   { href: "/subjects", label: "Bibliothek", icon: BookOpenIcon },
   { href: "/cases", label: "Leitsymptome", icon: ClipboardDocumentListIcon },
+  { href: "/pruefung", label: "Prüfungsmodus", icon: ChatBubbleLeftRightIcon },
   { href: "/simulate", label: "Examenssimulation", icon: AcademicCapIcon },
   { href: "/account", label: "Account", icon: UserCircleIcon },
   {

--- a/src/data/cases.ts
+++ b/src/data/cases.ts
@@ -6,6 +6,7 @@ import { hypertonie_001 } from "./innere/kardiologie/hypertonie_001";
 import { pankreatitis_001 } from "./innere/gastroenterologie/pankreatitis_001";
 import { spannungspneumothorax_001 } from "./chirurgie/Thoraxchirurgie/spannungspneumothorax_001";
 import { mm_001 } from "./innere/haematoonkologie/mm_001";
+import { aszites_001 } from "./innere/gastroenterologie/aszites_001";
 
 export const CASES = [
   brustschmerz_001,
@@ -15,5 +16,6 @@ export const CASES = [
   hypertonie_001,
   pankreatitis_001,
   spannungspneumothorax_001,
-  mm_001
+  mm_001,
+  aszites_001,
 ];

--- a/src/data/innere/gastroenterologie/aszites_001.ts
+++ b/src/data/innere/gastroenterologie/aszites_001.ts
@@ -1,0 +1,327 @@
+// src/data/innere/gastroenterologie/aszites_001.ts
+import type { Case } from "@/lib/types";
+
+export const aszites_001: Case = {
+  id: "aszites_001",
+  title: "Bauchumfangszunahme und Dyspnoe",
+  shortTitle: "Aszites",
+  leadSymptom: "Abdominelle Schwellung",
+  pseudonym: "Aszites_001",
+  vignette:
+    "Sie sind Arzt in der Notaufnahme. Ein 58-jähriger Patient stellt sich bei Ihnen vor. Er berichtet über einen seit Wochen zunehmenden Bauchumfang, Spannungsgefühl im Abdomen und Belastungsdyspnoe. Wie gehen Sie vor?",
+  specialty: "Innere Medizin",
+  subspecialty: "Gastroenterologie",
+  difficulty: 3,
+  tags: ["Aszites", "Portale Hypertension", "Leberzirrhose", "Ösophagusvarizen"],
+
+  steps: [
+    {
+      order: 1,
+      points: 2,
+      prompt: "Welche anamnestischen Fragen stellen Sie?",
+      hint: "Lebererkrankung, Blutungen, Risikofaktoren, B-Symptomatik",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Alkoholkonsum",
+          "Risikofaktoren",
+          "Rauchen",
+          "Vorerkrankungen",
+          "(Vor-) Operationen",
+          "B-Symptomatik (Gewichtsverlust, Schwitzen, Fieber)",
+          "Medikation",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 2,
+      points: 2,
+      prompt: "Sie wollen nun den Patienten körperlich untersuchen, auf was achten Sie im Speziellen?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Bauchumfang vergrößert",
+          "prall gefüllter Bauch",
+          "Aszites nachweisbar (Flüssigkeitswelle, shifting dullness)",
+          "Ödeme",
+          "Splenomegalie",
+          "Ikterus",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 3,
+      points: 2,
+      prompt: "Welche initiale Diagnostik ist indiziert?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Sonografie des Abdomens",
+          "Labor (Leberwerte, Gerinnung, Kreatinin, Elektrolyte)",
+          "Aszitespunktion (Untersuchung Eiweiß, Zellzahl, Mikrobiologie)",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 4,
+      points: 3,
+      prompt:
+        "Sie entschließen sich, eine Abdomensonografie durchzuführen. Dabei ergibt sich folgendes Bild. Beschreiben Sie:",
+      rule: {
+        mode: "anyOf",
+        expected: ["Aszites", "Echoleere Flüssigkeit um die Leber", "Hinweis auf Leberzirrhose"],
+        minHits: 2,
+      },
+      image: {
+        path: "Ultraschall/Aszites.JPG",
+        alt: "Sonografie mit freier Flüssigkeit im Abdomen",
+        caption: "Sonografie des Abdomens: Nachweis von Aszites (freie Flüssigkeit).",
+      },
+    },
+    {
+      order: 5,
+      points: 2,
+      prompt:
+        "Sie haben die anschließende diagnostische Aszitespunktion erfolgreich durchgeführt und wollen nun eine Probe davon zum Labor schicken. Welche Laborparameter sind dabei von besonderem Interesse?",
+      rule: {
+        mode: "anyOf",
+        expected: ["Zellzahl", "Eiweißgehalt", "Mikrobiologische Untersuchung"],
+        minHits: 2,
+      },
+    },
+    {
+      order: 6,
+      points: 3,
+      prompt:
+        "Inzwischen ist auch folgender Laborbefund des Blutes eingetroffen. Interpretieren Sie erst die Ergebnisse und äußern Sie eine dazu passende Differentialdiagnose.",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Erhöhte Transaminasen",
+          "Hypoalbuminämie",
+          "Erhöhte INR / Gerinnungsstörung",
+          "Leberzirrhose",
+          "Erhöhte Leberwerte",
+          "erhöhte cholestasewerte",
+          "Lebersynthesefunktion eingeschränkt",
+          "Gerinnungsstörung",
+        ],
+        minHits: 3,
+      },
+      image: {
+        path: "Labor/Leberzirrhose.png",
+        alt: "Laborbefund mit erhöhten Transaminasen und erniedrigtem Albumin",
+        caption: "Typischer Laborbefund bei fortgeschrittener Leberzirrhose.",
+      },
+    },
+    {
+      order: 7,
+      points: 3,
+      prompt: "Welche typischen Ursachen einer portalen Hypertension kennen Sie?",
+      hint: "Prä-, intra- und posthepatisch unterscheiden",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Pfortaderthrombose",
+          "Leberzirrhose",
+          "Schistosomiasis",
+          "Sinusoidales Okklusionssyndrom",
+          "Budd-Chiari-Syndrom",
+          "(Rechts)herzinsuffizienz",
+          "Pericarditis constrictiva",
+          "Leber(teil)resektion",
+        ],
+        minHits: 3,
+      },
+    },
+    {
+      order: 8,
+      points: 2,
+      prompt:
+        "Während Sie die Laborwerte interpretieren, klagt der Patient plötzlich über Schwindel, wird blass und beginnt Blut zu erbrechen. Welche Symptome deuten auf eine akute Varizenblutung hin?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Hämatemesis",
+          "Schockzeichen (Tachykardie, Hypotonie, Blässe, Kaltschweißigkeit)",
+          "Schwindel",
+          "Synkope",
+          "Frischblutiges Erbrechen",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 9,
+      points: 3,
+      prompt: "Welche sofortigen Maßnahmen zur Kreislaufstabilisierung leiten Sie ein?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Schocklage",
+          "Bluttransfusion je nach Schwere",
+          "Magensonde",
+          "Absaugen Blut",
+          "Schutzintubation als Aspirationsprophylaxe",
+          "Sauerstoffgabe",
+          "Volumentherapie",
+          "Anlage von großlumigen Zugängen",
+          "Vorbereitung einer Bluttransfusion",
+        ],
+        minHits: 2,
+      },
+    },
+    {
+      order: 10,
+      points: 3,
+      prompt: "Sie leiten umgehend die Notfallversorgung ein. Welches Verfahren ist hier abgebildet?",
+      rule: {
+        mode: "anyOf",
+        expected: ["Ösophagusvarizenligatur", "Gummibandligatur", "Endoskopische Ligatur"],
+        minHits: 1,
+      },
+      image: {
+        path: "Endoskopie/Oesophagusvarizenligatur.png",
+        alt: "Endoskopische Ligatur von Ösophagusvarizen",
+        caption: "Endoskopische Ligatur von Ösophagusvarizen.",
+      },
+    },
+    {
+      order: 11,
+      points: 3,
+      prompt:
+        "Welche spezifischen Therapien zur Blutstillung bei Ösophagusvarizenblutung kommen außerdem infrage ?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Terlipressin oder Somatostatin/Octreotid",
+          "Sklerotherapie (falls Ligatur nicht möglich)",
+          "Ballontamponade (Sengstaken-Blakemore-Sonde) als Notfallmaßnahme",
+          "Stenting Ösophagus",
+          "TIPS",
+        ],
+        minHits: 1,
+      },
+    },
+    {
+      order: 12,
+      points: 2,
+      prompt:
+        "Welche Maßnahmen ergreifen Sie zur Sekundärprophylaxe nach einer überstandenen Varizenblutung?",
+      rule: {
+        mode: "anyOf",
+        expected: [
+          "Nicht-selektive Betablocker (z.B. Propranolol)",
+          "Regelmäßige endoskopische Ligatur",
+          "TIPS bei rezidivierender Blutung",
+          "Alkoholkarenz",
+          "Therapie der Grunderkrankung (Leberzirrhose)",
+        ],
+        minHits: 2,
+      },
+    },
+  ],
+
+  objectives: [
+    { id: "diagnose", label: "Aszites diagnostizieren" },
+    { id: "ursachen", label: "Ätiologie der portalen Hypertension benennen" },
+    { id: "notfall", label: "Akute Varizenblutung erkennen und behandeln" },
+    { id: "therapie", label: "Therapieoptionen und Prophylaxe darstellen" },
+  ],
+
+  completion: { minObjectives: 4, maxLLMTurns: 20, hardStopTurns: 20 },
+
+  interactive: {
+    initial: ["anamnese"],
+    intro: "Welche Untersuchung oder Maßnahme führen Sie als erstes durch?",
+    fallbacks: {
+      locked: "Diese Maßnahme ist noch nicht zugänglich. Arbeiten Sie zunächst die Basisdiagnostik ab.",
+      unknown: "Ich habe Sie nicht verstanden. Was möchten Sie als Nächstes tun?",
+      finished: "Der Fall ist abgeschlossen. Sie können den Ablauf über den Reset neu starten.",
+    },
+    completion: {
+      afterActions: ["sekundaerprophylaxe"],
+      message: "Fall abgeschlossen – gute Arbeit!",
+    },
+    actions: {
+      anamnese: {
+        keywords: ["anamnese", "fragen", "vorerkrankungen", "alkohol", "medikamente"],
+        response:
+          "Sie erheben die Anamnese: Alkoholkonsum, Risikofaktoren, Vorerkrankungen, Operationen, Medikamente, B-Symptomatik.",
+        unlocks: ["koerperliche_untersuchung", "labor", "sonografie"],
+      },
+      koerperliche_untersuchung: {
+        keywords: ["untersuchung", "körperlich", "bauch"],
+        response:
+          "Körperliche Untersuchung: Vergrößerter Bauchumfang, prall gefüllter Bauch, Aszites nachweisbar, Ödeme, evtl. Splenomegalie und Ikterus.",
+        unlocks: ["sonografie", "labor"],
+      },
+      sonografie: {
+        keywords: ["sono", "ultraschall", "bild"],
+        response: "Sonografie: echoleere Flüssigkeit um die Leber, freie Flüssigkeit im Abdomen.",
+        image: {
+          path: "Ultraschall/Aszites.JPG",
+          alt: "Sonografie mit freier Flüssigkeit im Abdomen",
+          caption: "Sonografie des Abdomens.",
+        },
+        unlocks: ["aszitespunktion"],
+      },
+      labor: {
+        keywords: ["labor", "blutbild", "werte"],
+        response: "Labor: Transaminasen ↑, Albumin ↓, INR ↑.",
+        image: {
+          path: "Labor/Leberzirrhose.png",
+          alt: "Laborbefund mit veränderten Leberwerten",
+          caption: "Laborbefund bei Leberzirrhose.",
+        },
+        unlocks: ["differenzialdiagnose"],
+      },
+      aszitespunktion: {
+        keywords: ["punktion", "aszites", "flüssigkeit"],
+        response: "Aszitespunktion: Eiweißgehalt, Zellzahl, Mikrobiologie.",
+        unlocks: ["differenzialdiagnose"],
+      },
+      differenzialdiagnose: {
+        keywords: ["diagnose", "differenzial"],
+        response:
+          "Differenzialdiagnosen portaler Hypertension: Leberzirrhose, Pfortaderthrombose, Schistosomiasis, Budd-Chiari-Syndrom, Rechtsherzinsuffizienz, Pericarditis constrictiva.",
+        unlocks: ["notfall_varizenblutung"],
+      },
+      notfall_varizenblutung: {
+        keywords: ["notfall", "blutung", "varizen"],
+        response: "Während der Untersuchung: Patient klagt über Schwindel, wird blass und erbricht Blut.",
+        unlocks: ["notfall_massnahmen"],
+      },
+      notfall_massnahmen: {
+        keywords: ["maßnahmen", "stabilisierung", "schock"],
+        response:
+          "Sofortmaßnahmen: Schocklage, großlumige Zugänge, Volumentherapie, Sauerstoffgabe, Absaugen/Magensonde, ggf. Schutzintubation, Bluttransfusion vorbereiten.",
+        unlocks: ["endoskopie"],
+      },
+      endoskopie: {
+        keywords: ["endoskopie", "ligatur", "varizen"],
+        response: "Endoskopisches Vorgehen: Ösophagusvarizenligatur (Gummibandligatur).",
+        image: {
+          path: "Endoskopie/Oesophagusvarizenligatur.png",
+          alt: "Endoskopische Ligatur von Ösophagusvarizen",
+          caption: "Endoskopische Ligatur.",
+        },
+        unlocks: ["blutstillung_medikament"],
+      },
+      blutstillung_medikament: {
+        keywords: ["therapie", "blutstillung", "medikamente"],
+        response:
+          "Medikamentöse Blutstillung: Terlipressin oder Somatostatin/Octreotid; weitere Optionen sind Sklerotherapie, Ballontamponade, Stenting, TIPS.",
+        unlocks: ["sekundaerprophylaxe"],
+      },
+      sekundaerprophylaxe: {
+        keywords: ["prophylaxe", "sekundär", "vorbeugung"],
+        response:
+          "Sekundärprophylaxe: nicht-selektive Betablocker, regelmäßige endoskopische Ligaturen, TIPS bei Rezidiv, Alkoholkarenz, Therapie der Grunderkrankung.",
+      },
+    },
+  },
+};

--- a/src/lib/interactive-engine.ts
+++ b/src/lib/interactive-engine.ts
@@ -1,0 +1,110 @@
+// src/lib/interactive-engine.ts
+import type { Case, InteractiveAction, InteractiveFlow } from "./types";
+
+export type InteractiveEvalSuccess = {
+  type: "success";
+  actionId: string;
+  response: string;
+  image?: InteractiveAction["image"];
+  newlyUnlocked: string[];
+  finished: boolean;
+  completionMessage?: string;
+};
+
+export type InteractiveEvalLocked = {
+  type: "locked";
+  actionId: string;
+  message?: string;
+};
+
+export type InteractiveEvalUnknown = {
+  type: "unknown";
+  message?: string;
+};
+
+export type InteractiveEvalFinished = {
+  type: "finished";
+  message?: string;
+};
+
+export type InteractiveEvalResult =
+  | InteractiveEvalSuccess
+  | InteractiveEvalLocked
+  | InteractiveEvalUnknown
+  | InteractiveEvalFinished;
+
+export class InteractiveCaseEngine {
+  private readonly flow: InteractiveFlow;
+  private readonly unlocked: Set<string>;
+  private completed: boolean;
+
+  constructor(caseData: Case) {
+    if (!caseData.interactive) {
+      throw new Error("Case does not provide an interactive flow");
+    }
+    this.flow = caseData.interactive;
+    this.unlocked = new Set(this.flow.initial && this.flow.initial.length ? this.flow.initial : []);
+    this.completed = false;
+  }
+
+  getIntro(): string | null {
+    return this.flow.intro ?? null;
+  }
+
+  handleInput(input: string): InteractiveEvalResult {
+    if (this.completed) {
+      return {
+        type: "finished",
+        message: this.flow.fallbacks?.finished,
+      };
+    }
+
+    const normalized = input.toLowerCase();
+
+    for (const [id, action] of Object.entries(this.flow.actions)) {
+      const hit = action.keywords.some((kw) => normalized.includes(kw.toLowerCase()));
+      if (!hit) continue;
+
+      if (!this.unlocked.has(id)) {
+        return {
+          type: "locked",
+          actionId: id,
+          message: this.flow.fallbacks?.locked,
+        };
+      }
+
+      const newlyUnlocked = Array.from(new Set(action.unlocks ?? []));
+      for (const next of newlyUnlocked) this.unlocked.add(next);
+
+      const finished = Boolean(this.flow.completion?.afterActions?.includes(id));
+      if (finished) {
+        this.completed = true;
+      }
+
+      return {
+        type: "success",
+        actionId: id,
+        response: action.response,
+        image: action.image,
+        newlyUnlocked,
+        finished,
+        completionMessage: finished ? this.flow.completion?.message : undefined,
+      };
+    }
+
+    return {
+      type: "unknown",
+      message: this.flow.fallbacks?.unknown,
+    };
+  }
+
+  reset(): void {
+    this.unlocked.clear();
+    if (this.flow.initial) {
+      for (const it of this.flow.initial) {
+        this.unlocked.add(it);
+      }
+    }
+    this.completed = false;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,33 @@ export type StepImage = {
   caption?: string;      // optionale Bildunterschrift
 };
 
+// ---------- Interaktiver Prüfungsmodus ----------
+export type InteractiveAction = {
+  keywords: string[];          // Schlüsselwörter, die die Aktion triggern
+  response: string;            // Antworttext des Tutors
+  image?: StepImage;           // optionales Bild zur Aktion
+  unlocks?: string[];          // weitere Aktionen, die danach freigeschaltet werden
+};
+
+export type InteractiveCompletion = {
+  afterActions?: string[];     // nach welchen Aktionen der Fall als abgeschlossen gilt
+  message?: string;            // Abschlusstext
+};
+
+export type InteractiveFallbacks = {
+  locked?: string;             // Meldung, wenn Aktion noch gesperrt ist
+  unknown?: string;            // Meldung, wenn keine Aktion erkannt wird
+  finished?: string;           // Meldung nach Abschluss des Falls
+};
+
+export type InteractiveFlow = {
+  initial?: string[];                          // initial freigeschaltete Aktionen
+  intro?: string;                              // optionaler Intro-Satz nach der Vignette
+  actions: Record<string, InteractiveAction>;  // alle Aktionen
+  completion?: InteractiveCompletion;          // Abschlusslogik
+  fallbacks?: InteractiveFallbacks;            // Standardtexte für Sonderfälle
+};
+
 // ---------- Regeln (Auswertung) ----------
 export type CategoriesRule = {
   mode: "categories";
@@ -132,6 +159,7 @@ export type Case = {
 
   // Inhalt
   steps: Step[];              // die einzelnen Prüfungs-/Lernschritte
+  interactive?: InteractiveFlow; // optionaler interaktiver Prüfungsmodus
 
   // Lernziele/Abschluss
   objectives: LearningObjective[];


### PR DESCRIPTION
## Summary
- extend case types with interactive flow definitions and add an engine to evaluate unlocked actions
- add an aszites case that exposes a full unlock-based conversation path for the new Prüfungsmodus
- introduce Prüfungsmodus navigation and pages to play through interactive cases with tutor-style feedback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caa004b8d483308c292c886a2eca29