### PR TITLE
Hide question order on mobile

### DIFF
--- a/src/app/exam/[id]/page.tsx
+++ b/src/app/exam/[id]/page.tsx
@@ -968,8 +968,7 @@ function createReflectionSnapshot(): void {
         {/* Linke Spalte */}
         <aside
           ref={sidebarRef}
-          className="rounded-xl border border-black/10 bg-white/70 p-3 md:sticky md:top-20
-                     overflow-y-auto max-h-[calc(100vh-120px)]"
+          className="hidden max-h-[calc(100vh-120px)] overflow-y-auto rounded-xl border border-black/10 bg-white/70 p-3 md:sticky md:top-20 md:block"
         >
           <div className="mb-2 text-xs font-medium text-gray-700">Fragenfolge</div>
           <ul className="space-y-2">
@@ -1133,7 +1132,7 @@ function createReflectionSnapshot(): void {
         ended
           ? "Fall beendet"
           : !hasStarted
-          ? "Zum Start bitte links klicken"
+          ? "Zum Start bitte „Prüfung starten“ wählen"
           : viewIndex !== activeIndex
           ? "Nur Ansicht – zurück zur aktuellen Frage wechseln"
           : "Deine Antwort…"

--- a/src/app/simulate/[id]/page.tsx
+++ b/src/app/simulate/[id]/page.tsx
@@ -558,7 +558,7 @@ const totalScorePct = useMemo<number>(() => {
       {/* Zwei Spalten */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-[var(--steps-w,260px)_1fr]">
         {/* Linke Spalte */}
-        <aside className="h-fit rounded-xl border border-black/10 bg-white/70 p-3 md:sticky md:top-20">
+        <aside className="hidden h-fit rounded-xl border border-black/10 bg-white/70 p-3 md:sticky md:top-20 md:block">
           <div className="mb-2 text-xs font-medium text-gray-700">Fragenfolge</div>
           <ul className="space-y-2">
             {asked.map((a) => {
@@ -663,7 +663,7 @@ const totalScorePct = useMemo<number>(() => {
                 ended
                   ? "Fall beendet"
                   : !hasStarted
-                  ? "Zum Start bitte links klicken"
+                  ? "Zum Start bitte „Prüfung starten“ wählen"
                   : (viewIndex !== activeIndex)
                   ? "Nur Ansicht – zurück zur aktuellen Frage wechseln"
                   : "Deine Antwort…"

--- a/src/components/QuestionSidebar.tsx
+++ b/src/components/QuestionSidebar.tsx
@@ -25,8 +25,7 @@ export default function QuestionSidebar({ steps, activeOrder, onSelect }: Props)
   return (
     <aside
       ref={sidebarRef}
-      className="rounded-xl border border-black/10 bg-white/70 p-3 md:sticky md:top-20
-                 overflow-y-auto max-h-[calc(100vh-120px)]"
+      className="hidden max-h-[calc(100vh-120px)] overflow-y-auto rounded-xl border border-black/10 bg-white/70 p-3 md:sticky md:top-20 md:block"
     >
       <div className="mb-2 text-xs font-medium text-gray-700">Fragenfolge</div>
       <ul className="space-y-2">


### PR DESCRIPTION
## Summary
- hide the question order sidebar on mobile to maximize space for the exam flow
- adjust mobile placeholder text to reference the start button instead of the sidebar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d654ce79008330be35e7e80fed3dd1